### PR TITLE
added support for webac_roles_provider

### DIFF
--- a/src/webac/webapp/WEB-INF/classes/spring/auth-repo.xml
+++ b/src/webac/webapp/WEB-INF/classes/spring/auth-repo.xml
@@ -41,6 +41,8 @@
 
     <bean name="fad" class="org.fcrepo.auth.webac.WebACAuthorizationDelegate"/>
 
+    <bean name="accessRolesProvider" class="org.fcrepo.auth.webac.WebACRolesProvider"/>
+
     <bean name="authenticationProvider" class="org.fcrepo.auth.common.ServletContainerAuthenticationProvider">
       <property name="fad" ref="fad"/>
       <property name="principalProviders" ref="principalProviderSet"/>


### PR DESCRIPTION
This is a follow-on PR, related to https://github.com/fcrepo4-labs/fcrepo-module-auth-webac/pull/28 (and dependent on that PR).

It adds support for a custom `AccessRolesProvider` class defined in the WebAC module.