### PR TITLE
Remove MaxPermSize flag from maven configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <argLine>-XX:MaxPermSize=128m ${jacoco.agent.it.arg} -Dauth.enabled=${auth.enabled}</argLine>
+          <argLine>${jacoco.agent.it.arg} -Dauth.enabled=${auth.enabled}</argLine>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
java8 no longer uses the -XX:MaxPermSize flag; this PR removes that from the build machinery.