### PR TITLE
Update version to 5.0.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,56 +44,6 @@ that this may break the single integration test.
 
 You must also configure the authorization package as described below.
 
-## Role-Based Access Control Lists
-
-####This has been deprecated, please use WebAC Access Control.
-
-Ensure you have the basic authentication enabled in the web.xml. 
-
-Then comment out the WebAC beans and un-comment the RbAcl beans in your `fcrepo-config.xml` file.
-
-```
-    <!-- **** WebAC Authentication **** -->
-    <!--
-      <bean name="fad" class="org.fcrepo.auth.webac.WebACAuthorizationDelegate"/>
-      <bean name="accessRolesProvider" class="org.fcrepo.auth.webac.WebACRolesProvider"/>
-    -->
-    <!-- **** Roles Based Authentication **** -->
-      <bean name="accessRolesResources" class="org.fcrepo.auth.roles.common.AccessRolesResources"/>
-      <bean name="fad" class="org.fcrepo.auth.roles.basic.BasicRolesAuthorizationDelegate"/>
-
-```
-
-You will also need to include/un-comment the `fcrepo-module-auth-rbacl` artifact dependency in the pom.xml.
-
-## XACML-based Access Control
-
-####This has been deprecated, please use WebAC Access Control.
-
-Ensure you have the basic authentication enabled in the web.xml. 
-
-Default policy sets and root policy are extracted into target/policies for the integration
-tests, but when you create a custom war file, you should update the repo.xml Spring
-configuration to point to your own policy directories.
-
-You must also comment out the WebAC beans and un-comment the XACML ones.
-
-```
-    <!-- **** WebAC Authentication **** -->
-    <!--
-      <bean name="fad" class="org.fcrepo.auth.webac.WebACAuthorizationDelegate"/>
-      <bean name="accessRolesProvider" class="org.fcrepo.auth.webac.WebACRolesProvider"/>
-    -->
-    <!-- **** XACML Authentication **** -->
-      <bean name="accessRolesResources" class="org.fcrepo.auth.roles.common.AccessRolesResources"/>
-      <bean class="org.fcrepo.auth.xacml.XACMLWorkspaceInitializer" init-method="initTest">
-        <constructor-arg value="WEB-INF/classes/policies"/>
-        <constructor-arg value="WEB-INF/classes/policies/GlobalRolesPolicySet.xml"/>
-      </bean>
-
-```
-
-You will also need to include/un-comment the `fcrepo-module-auth-xacml` artifact dependency in the pom.xml.
 
 # Audit Capability Package
 The [fcrepo-audit](https://github.com/fcrepo4-exts/fcrepo-audit) capability is included in fcrepo-webapp-plus by default.

--- a/pom.xml
+++ b/pom.xml
@@ -3,10 +3,10 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-webapp-plus</artifactId>
-  <version>4.8.0-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>fcrepo-webapp-plus</name>
   <description>Fedora Repository webapp plus additional modules</description>
@@ -47,20 +47,20 @@
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-webapp</artifactId>
-      <version>4.8.0-SNAPSHOT</version>
+      <version>5.0.0-SNAPSHOT</version>
       <type>war</type>
     </dependency>
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-webapp</artifactId>
-      <version>4.8.0-SNAPSHOT</version>
+      <version>5.0.0-SNAPSHOT</version>
       <type>jar</type>
       <classifier>classes</classifier>
     </dependency>
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-mint</artifactId>
-      <version>4.8.0-SNAPSHOT</version>
+      <version>5.0.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -104,39 +104,19 @@
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-audit</artifactId>
-      <version>4.8.0-SNAPSHOT</version>
+      <version>5.0.0-SNAPSHOT</version>
     </dependency>
-    <!-- Role Based Authorization 
-      NOTE: This has been deprecated, please use 
-      fcrepo-module-auth-webac -->
-    <!--
-    <dependency>
-      <groupId>org.fcrepo</groupId>
-      <artifactId>fcrepo-module-auth-rbacl</artifactId>
-      <version>4.8.0-SNAPSHOT</version>
-    </dependency>
-    -->
-    <!-- XACML Authorization
-      NOTE: This has been deprecated, please use 
-      fcrepo-module-auth-webac -->
-    <!--
-    <dependency>
-      <groupId>org.fcrepo</groupId>
-      <artifactId>fcrepo-module-auth-xacml</artifactId>
-      <version>4.8.0-SNAPSHOT</version>
-    </dependency>
-    -->
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-http-commons</artifactId>
-      <version>4.8.0-SNAPSHOT</version>
+      <version>5.0.0-SNAPSHOT</version>
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-http-api</artifactId>
-      <version>4.8.0-SNAPSHOT</version>
+      <version>5.0.0-SNAPSHOT</version>
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
@@ -271,15 +251,6 @@
                 </systemProperty>
 
                 <systemProperty>
-                  <name>fcrepo.xacml.initial.policies.dir</name>
-                  <value>${project.build.directory}/policies</value>
-                </systemProperty>
-
-                <systemProperty>
-                  <name>fcrepo.xacml.initial.root.policy.file</name>
-                  <value>${project.build.directory}/policies/GlobalRolesPolicySet.xml</value>
-                </systemProperty>
-                <systemProperty>
                   <name>auth.enabled</name>
                   <value>${auth.enabled:false}</value>
                 </systemProperty>
@@ -357,7 +328,7 @@
         <dependency>
           <groupId>org.fcrepo</groupId>
           <artifactId>fcrepo-module-auth-webac</artifactId>
-          <version>4.8.0-SNAPSHOT</version>
+          <version>5.0.0-SNAPSHOT</version>
         </dependency>
       </dependencies>
       <build>

--- a/src/main/webapp/WEB-INF/classes/spring/fcrepo-config.xml
+++ b/src/main/webapp/WEB-INF/classes/spring/fcrepo-config.xml
@@ -83,21 +83,6 @@
       <bean name="accessRolesProvider" class="org.fcrepo.auth.webac.WebACRolesProvider"/>
       -->
     
-    <!-- **** Roles Based Authentication **** -->
-    <!--
-      <bean name="accessRolesResources" class="org.fcrepo.auth.roles.common.AccessRolesResources"/>
-      <bean name="fad" class="org.fcrepo.auth.roles.basic.BasicRolesAuthorizationDelegate"/>
-    -->
-      
-    <!-- **** XACML Authentication **** -->
-    <!--
-      <bean name="accessRolesResources" class="org.fcrepo.auth.roles.common.AccessRolesResources"/>
-      <bean class="org.fcrepo.auth.xacml.XACMLWorkspaceInitializer" init-method="initTest">
-        <constructor-arg value="WEB-INF/classes/policies"/>
-        <constructor-arg value="WEB-INF/classes/policies/GlobalRolesPolicySet.xml"/>
-      </bean>
-   -->
-    
 
     <!-- Creates a servlet container authentication provider with the supplied FAD and set
          of principles providers.

--- a/src/webac/webapp/WEB-INF/classes/spring/fcrepo-config.xml
+++ b/src/webac/webapp/WEB-INF/classes/spring/fcrepo-config.xml
@@ -33,7 +33,7 @@
     <!-- To use Authentication:
       1. Comment out the above bean definition.
       2. Uncomment this bean definition.
-      3. Uncomment one of the provider definitions (WebAC, Roles Based, XACML)
+      3. Uncomment one of the provider definitions (WebAC)
       4. Uncomment the "authenticationProvider" bean definition below.
     -->
     
@@ -80,21 +80,6 @@
     <!-- **** WebAC Authentication **** -->
       <bean name="fad" class="org.fcrepo.auth.webac.WebACAuthorizationDelegate"/>
       <bean name="accessRolesProvider" class="org.fcrepo.auth.webac.WebACRolesProvider"/>
-    
-    <!-- **** Roles Based Authentication **** -->
-    <!--
-      <bean name="accessRolesResources" class="org.fcrepo.auth.roles.common.AccessRolesResources"/>
-      <bean name="fad" class="org.fcrepo.auth.roles.basic.BasicRolesAuthorizationDelegate"/>
-    -->
-      
-    <!-- **** XACML Authentication **** -->
-    <!--
-      <bean name="accessRolesResources" class="org.fcrepo.auth.roles.common.AccessRolesResources"/>
-      <bean class="org.fcrepo.auth.xacml.XACMLWorkspaceInitializer" init-method="initTest">
-        <constructor-arg value="WEB-INF/classes/policies"/>
-        <constructor-arg value="WEB-INF/classes/policies/GlobalRolesPolicySet.xml"/>
-      </bean>
-   -->
     
 
     <!-- Creates a servlet container authentication provider with the supplied FAD and set


### PR DESCRIPTION
Also, remove references to deprecated xacml and rbacl in text,
comments, config files, etc


**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2575

# What does this Pull Request do?
Bumps the version to `5.0.0-SNAPSHOT`, and uses `5.0.0-SNAPSHOT` dependencies.  Also removes references to deprecated xacml and rbacl modules in text, comments, config files, etc.

# What's new?
Development on master breaks the 5.0.0 threshold, and invites breaking API changes.  This PR uses 5.0.0-SNAPSHOT dependencies, and removes deprecated xacml and rbacl modules.

# How should this be tested?

* Build Fedora, `fcrepo-mint`, `fcrepo-module-auth-webac`, `fcrepo-audit` `5.0.0-SNAPSHOT` via `mvn clean install`
* Build `fcrepo-webapp-plus`
* Make sure build succeeds.  Feel free to drop webapp plus into a servlet container and try it out.

# Interested parties
@fcrepo4/committers
